### PR TITLE
added overflow flag

### DIFF
--- a/paper-collapse.html
+++ b/paper-collapse.html
@@ -63,7 +63,7 @@ Example:
 				<div flex id="label">{{label}}</div>
 				<core-icon icon="{{opened ? openedIcon : closedIcon}}" id="toggleIcon"></core-icon>
 			</div>
-			<core-collapse id="collapse" opened?="{{opened}}">
+			<core-collapse id="collapse" opened?="{{opened}}" allowOverflow?="{{allowOverflow}}">
 				<content></content>
 			</core-collapse>
 		</div>
@@ -72,6 +72,13 @@ Example:
 		Polymer(
 			{
 				publish: {
+					/**
+					* Flag allowing the content to overflow the clipped container or not. Useful for dropdowns or similar.
+					*
+					* @property allowOverflow
+					* @type Boolean
+					*/					
+					allowOverflow: false,
 					/**
 	        * The toggle icon to display when the `paper-collapse` is closed.
 	        *


### PR DESCRIPTION
Parses **allowOverflow** flag from `paper-collapse` element down to the `core-collapse` element to allow the content to overflow the clipped area of the collapse. Useful for dropdown menus or similar...
